### PR TITLE
Fix crawler error handling

### DIFF
--- a/src/crawler/crawler.py
+++ b/src/crawler/crawler.py
@@ -5,7 +5,7 @@ import time
 import logging
 import validators
 from concurrent.futures import ThreadPoolExecutor
-from queue import Queue
+from queue import Queue, Empty
 import threading
 
 class WebCrawler:
@@ -66,7 +66,7 @@ class WebCrawler:
                 # キューから次のURLを取得
                 try:
                     current_url, source_url = self.url_queue.get(timeout=5)
-                except:
+                except Empty:
                     # キューが空で、すべてのタスクが終了したら終了
                     if all(future.done() for future in futures):
                         break


### PR DESCRIPTION
## Summary
- improve queue handling in crawler

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for requests and pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6850fefc5a188331b1e7e7d96d2b7cf7